### PR TITLE
Add emails_emre_ozcan.py

### DIFF
--- a/Week05/emails_emre_ozcan.py
+++ b/Week05/emails_emre_ozcan.py
@@ -1,0 +1,23 @@
+
+class Emails(list):
+    def __init__(self, addresses: list):
+        for i, address in enumerate(addresses):
+            if not self.validate(address):
+                raise ValueError(f"invalid address {address!r} at index {i}")
+        super().__init__(set(addresses))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({super().__repr__()})"
+
+    def __str__(self):
+        return super().__str__()
+
+    @property
+    def data(self):
+        return self
+
+    @staticmethod
+    def validate(address: str) -> bool:
+        if not isinstance(address, str):
+            raise ValueError("address must be a str")
+        return "@" in address and "." in address


### PR DESCRIPTION
Emails.validate() throws a ValueError instead of a TypeError if you provide a non-str address to conform to the tests.

## Describe your changes

## Checklist
- [x] I have read the [CONTRIBUTING]
- [x] I have performed a self-review of my own code
- [x] I have run the code locally and it works as expected
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots (if appropriate)
<!-- Add screenshots here if appropriate -->
